### PR TITLE
PhoneType: added SQL comment hint

### DIFF
--- a/src/IPub/DoctrinePhone/Types/Phone.php
+++ b/src/IPub/DoctrinePhone/Types/Phone.php
@@ -73,4 +73,14 @@ class Phone extends Types\StringType
 
 		return $value;
 	}
+
+	/**
+	 * @param Platforms\AbstractPlatform $platform
+	 *
+	 * @return bool
+	 */
+	public function requiresSQLCommentHint(Platforms\AbstractPlatform $platform)
+	{
+		return TRUE;
+	}
 }


### PR DESCRIPTION
Without the comment hint, Doctrine's reverse-engineering algorithm has no way to tell that a column is of type `phone`. As a result, `orm:validate-schema` complains about database being out of sync and `migrations:diff` always generates an ALTER statement changing the column to varchar. That's not nice :)

fixes #1 