### PR TITLE
Remove dependency on deprecated Nette\Object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 env:
   - NETTE=default
-  - NETTE=~2.3.0
+  - NETTE=~2.4.0
 
 php:
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,14 @@
 
 		"ipub/phone"	: "~1.2",
 
-		"nette/di"			: "~2.3",
-		"nette/utils"		: "~2.3"
+		"nette/di"			: "~2.4",
+		"nette/utils"		: "~2.4"
 	},
 
 	"require-dev": {
-		"nette/bootstrap"		: "~2.3",
-		"nette/mail"			: "~2.3",
-		"nette/robot-loader"	: "~2.3",
+		"nette/bootstrap"		: "~2.4",
+		"nette/mail"			: "~2.4",
+		"nette/robot-loader"	: "~2.4",
 		"nette/safe-stream"		: "~2.3",
 		"nette/tester"			: "@dev",
 

--- a/src/IPub/DoctrinePhone/Events/PhoneObjectSubscriber.php
+++ b/src/IPub/DoctrinePhone/Events/PhoneObjectSubscriber.php
@@ -37,8 +37,10 @@ use IPub\Phone;
  *
  * @author         Adam Kadlec <adam.kadlec@fastybird.com>
  */
-final class PhoneObjectSubscriber extends Nette\Object implements Common\EventSubscriber
+final class PhoneObjectSubscriber implements Common\EventSubscriber
 {
+	use Nette\SmartObject;
+
 	/**
 	 * @var Common\Annotations\Reader
 	 */


### PR DESCRIPTION
- added usage of trait "Nette\SmartObject" instead of deprecated parent
  class "Nette\Object"
- changed versions of nette packages to ~2.4
- changed Nette version in travis.yml to 2.4